### PR TITLE
feat!: add keyboard shortcuts for terminal navigation

### DIFF
--- a/frontend/src/lib/components/Tooltip.svelte
+++ b/frontend/src/lib/components/Tooltip.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { fade } from 'svelte/transition';
+
+    export let text: string;
+    export let position: 'top' | 'bottom' | 'left' | 'right' = 'top';
+    export let delay = 300;
+
+    let tooltipVisible = false;
+    let tooltipElement: HTMLDivElement;
+    let triggerElement: HTMLDivElement;
+    let timeoutId: NodeJS.Timeout;
+
+    function showTooltip() {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+            tooltipVisible = true;
+        }, delay);
+    }
+
+    function hideTooltip() {
+        clearTimeout(timeoutId);
+        tooltipVisible = false;
+    }
+
+    onMount(() => {
+        return () => {
+            clearTimeout(timeoutId);
+        };
+    });
+</script>
+
+<div
+    bind:this={triggerElement}
+    on:mouseenter={showTooltip}
+    on:mouseleave={hideTooltip}
+    on:focusin={showTooltip}
+    on:focusout={hideTooltip}
+    class="relative inline-block"
+>
+    <slot />
+    {#if tooltipVisible}
+        <div
+            bind:this={tooltipElement}
+            transition:fade={{ duration: 100 }}
+            class="absolute z-50 px-2 py-1 text-xs text-white bg-gray-900 rounded shadow-lg whitespace-nowrap"
+            class:top-0={position === 'top'}
+            class:bottom-0={position === 'bottom'}
+            class:left-0={position === 'left'}
+            class:right-0={position === 'right'}
+            class:-translate-y-full={position === 'top'}
+            class:translate-y-full={position === 'bottom'}
+            class:-translate-x-full={position === 'left'}
+            class:translate-x-full={position === 'right'}
+            class:mb-1={position === 'top'}
+            class:mt-1={position === 'bottom'}
+            class:mr-1={position === 'left'}
+            class:ml-1={position === 'right'}
+        >
+            {text}
+            <div
+                class="absolute w-2 h-2 bg-gray-900 transform rotate-45"
+                class:left-1/2={position === 'top' || position === 'bottom'}
+                class:top-1/2={position === 'left' || position === 'right'}
+                class:-translate-x-1/2={position === 'top' || position === 'bottom'}
+                class:-translate-y-1/2={position === 'left' || position === 'right'}
+                class:bottom-0={position === 'top'}
+                class:top-0={position === 'bottom'}
+                class:right-0={position === 'left'}
+                class:left-0={position === 'right'}
+                class:translate-y-1/2={position === 'top'}
+                class:-translate-y-1/2={position === 'bottom'}
+            />
+        </div>
+    {/if}
+</div>

--- a/frontend/src/lib/editor/Topbar.svelte
+++ b/frontend/src/lib/editor/Topbar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { ChevronLeft, ChevronRight, Search, GitBranch, Files, File } from 'lucide-svelte';
+  import { ChevronLeft, ChevronRight, Search, GitBranch, Files, File, Terminal } from 'lucide-svelte';
   import Input from '../components/Input.svelte';
   import { tooltip } from '@/lib/actions/tooltip';
+  import { terminalVisibility } from '@/stores/terminalStore';
 
   export let onToggleLeftSidebar: () => void;
   export let onToggleRightSidebar: () => void;
@@ -16,6 +17,10 @@
   export let modifiedFilesCount: number = 0;
 
   let searchQuery = '';
+
+  function toggleTerminal() {
+    terminalVisibility.update(v => !v);
+  }
 </script>
 
 <div class="h-12 bg-gray-900 border-b border-gray-700 flex items-center px-4">
@@ -49,6 +54,14 @@
           {modifiedFilesCount}
         </span>
       {/if}
+    </button>
+
+    <button
+      on:click={toggleTerminal}
+      class="p-2 hover:bg-gray-800 rounded-sm relative {$terminalVisibility ? 'bg-gray-800 text-gray-200' : 'text-gray-400'}"
+      use:tooltip={{ content: "Toggle Terminal", position: "bottom" }}
+    >
+      <Terminal size={16} />
     </button>
   </div>
 

--- a/frontend/src/lib/editor/panes/BottomPane.svelte
+++ b/frontend/src/lib/editor/panes/BottomPane.svelte
@@ -4,7 +4,8 @@
     import type { BottomPaneState } from '@/types/ui';
     import TerminalPane from '@/lib/editor/panes/TerminalPane.svelte';
     import { bottomPaneStore } from '@/stores/bottomPaneStore';
-    import { FilesIcon, TerminalIcon } from 'lucide-svelte';
+    import { FilesIcon } from 'lucide-svelte';
+    import { terminalVisibility } from '@/stores/terminalStore';
 
     export let state: BottomPaneState;
     export let height: number;
@@ -27,21 +28,7 @@
     }
 </script>
 
-<div class="w-full flex flex-col overflow-hidden border-t border-gray-800" style="height: {height}px">
-    <div class="flex items-center justify-between h-[35px] px-4 border-b border-gray-800">
-        <div class="flex items-center space-x-2">
-            <span class="text-sm font-medium flex gap-2">
-                {#if state.activeSection === 'terminal'}
-                    <TerminalIcon size={16} /> Terminal
-                {:else if state.activeSection === 'problems'}
-                    <FilesIcon size={16} /> Problems
-                {:else if state.activeSection === 'output'}
-                    <FilesIcon size={16} /> Output
-                {/if}
-            </span>
-        </div>
-    </div>
-
+<div class="w-full flex flex-col overflow-hidden border-t border-gray-800" style="height: {!$terminalVisibility && state.activeSection === 'terminal' ? 0 : height}px">
     <div class="flex-1 overflow-auto">
         {#if state.activeSection === 'terminal'}
             <TerminalPane {height} />

--- a/frontend/src/lib/editor/panes/TerminalPane.svelte
+++ b/frontend/src/lib/editor/panes/TerminalPane.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import XtermComponent from '@/lib/terminal/XtermComponent.svelte';
-    import { terminalStore, availableShells } from '@/stores/terminalStore';
+    import { terminalStore, availableShells, terminalVisibility } from '@/stores/terminalStore';
     import { bottomPaneStore } from '@/stores/bottomPaneStore';
-    import { Plus, X, ChevronLeft, ChevronRight } from 'lucide-svelte';
+    import { Plus, X, ChevronLeft, ChevronRight, Terminal } from 'lucide-svelte';
     import Button from '@/lib/components/Button.svelte';
     import Select from '@/lib/components/Select.svelte';
     import { get } from 'svelte/store';
@@ -77,7 +77,14 @@
     }
 </script>
 
-<div class="h-full w-full bg-gray-800 overflow-hidden flex flex-col">
+<div class="h-full w-full bg-gray-800 overflow-hidden flex flex-col" class:hidden={!$terminalVisibility}>
+    <div class="flex items-center justify-between h-[35px] px-4 border-b border-gray-700">
+        <div class="flex items-center space-x-2">
+            <span class="text-sm font-medium flex gap-2">
+                <Terminal size={16} /> Terminal
+            </span>
+        </div>
+    </div>
     <div class="flex items-center border-b border-gray-700">
         <div 
             bind:this={tabsContainer}

--- a/frontend/src/routes/Editor.svelte
+++ b/frontend/src/routes/Editor.svelte
@@ -141,30 +141,17 @@
             // Save current focus
             focusStore.focus('editor', $fileStore.activeFilePath || 'editor');
             
-            // Show terminal
+            // Just set the active section, no collapsing
             bottomPaneStore.update(state => ({
                 ...state,
-                collapsed: false,
                 activeSection: 'terminal'
             }));
         });
 
         // Register return to previous shortcut
         registerCommand('terminal.returnToPrevious', () => {
-            const previous = get(focusStore).previousContext;
-            if (previous && previous.component === 'editor') {
-                // Collapse terminal
-                bottomPaneStore.update(state => ({
-                    ...state,
-                    collapsed: true
-                }));
-
-                // Focus editor and file
-                focusStore.restorePrevious();
-                if (previous.id !== 'editor') {
-                    fileStore.setActiveFile(previous.id);
-                }
-            }
+            // Just focus back, no collapsing
+            focusStore.restorePrevious();
         });
 
         registerCommand('file.showFileFinder', () => showFileFinder = true);

--- a/frontend/src/stores/keyboardStore.ts
+++ b/frontend/src/stores/keyboardStore.ts
@@ -4,6 +4,7 @@ import { fileStore } from './fileStore';
 import { OpenConfigFile } from '@/lib/wailsjs/go/main/App';
 import { push } from 'svelte-spa-router';
 import { WindowReloadApp } from '@/lib/wailsjs/runtime/runtime';
+import { terminalVisibility } from './terminalStore';
 
 // Default keybindings configuration
 const defaultKeybindings: KeyBindingConfig = {
@@ -363,7 +364,9 @@ const defaultKeybindings: KeyBindingConfig = {
             category: 'Terminal',
             context: ['global']
         },
-        action: () => {}
+        action: () => {
+            terminalVisibility.set(true);
+        }
     },
     'terminal.returnToPrevious': {
         defaultBinding: {
@@ -373,7 +376,9 @@ const defaultKeybindings: KeyBindingConfig = {
             category: 'Terminal',
             context: ['bottomPane']
         },
-        action: () => {}
+        action: () => {
+            terminalVisibility.update(v => !v);
+        }
     },
 };
 

--- a/frontend/src/stores/terminalStore.ts
+++ b/frontend/src/stores/terminalStore.ts
@@ -13,6 +13,9 @@ export interface TerminalTab {
 // Initialize with a default shell that will be updated
 export const availableShells = writable<string[]>(['/bin/bash']);
 
+// Initialize with visibility control
+export const terminalVisibility = writable<boolean>(false);
+
 // Load available shells on startup
 GetAvailableShells().then(shells => {
     availableShells.set(shells);


### PR DESCRIPTION
⚠️ BREAKING CHANGE: Terminal keyboard shortcuts have changed:
- <Ctrl+J> now focuses on the terminal
- <Alt+J> returns to the last opened pane before the terminal

This pull request introduces a new tooltip component and adds functionality to toggle the terminal visibility in the editor. The most important changes include the addition of a `Tooltip` component, integration of terminal visibility toggle, and updates to the terminal pane and keyboard store.

### New Tooltip Component:

* [`frontend/src/lib/components/Tooltip.svelte`](diffhunk://#diff-61949dd110088323d7883a4ac41cf1505dfe6f2742ffca8d1b3b5f0fcebd0fc3R1-R76): Added a new `Tooltip` component with customizable text and position, which uses Svelte's `fade` transition.

### Terminal Visibility Toggle:

* [`frontend/src/lib/editor/Topbar.svelte`](diffhunk://#diff-78e3046cb3e9024d9d83fdba0f80474f0529a5d5afcc79a67faaa27d2a41953dL2-R5): Imported `terminalVisibility` from the store and added a button to toggle terminal visibility. [[1]](diffhunk://#diff-78e3046cb3e9024d9d83fdba0f80474f0529a5d5afcc79a67faaa27d2a41953dL2-R5) [[2]](diffhunk://#diff-78e3046cb3e9024d9d83fdba0f80474f0529a5d5afcc79a67faaa27d2a41953dR20-R23) [[3]](diffhunk://#diff-78e3046cb3e9024d9d83fdba0f80474f0529a5d5afcc79a67faaa27d2a41953dR58-R65)
* [`frontend/src/lib/editor/panes/BottomPane.svelte`](diffhunk://#diff-cbb4524eab8ac9688b8020c59ec01cdc89087c3e8fce9927eda16305b6014a6aL7-R8): Adjusted the height of the bottom pane based on terminal visibility. [[1]](diffhunk://#diff-cbb4524eab8ac9688b8020c59ec01cdc89087c3e8fce9927eda16305b6014a6aL7-R8) [[2]](diffhunk://#diff-cbb4524eab8ac9688b8020c59ec01cdc89087c3e8fce9927eda16305b6014a6aL30-R31)
* [`frontend/src/lib/editor/panes/TerminalPane.svelte`](diffhunk://#diff-5528ff946aa7212fedcb3a4bae8e67ebae5732609f0c91e1488851280ee3deb4L3-R5): Added a visibility check to the terminal pane and updated the layout. [[1]](diffhunk://#diff-5528ff946aa7212fedcb3a4bae8e67ebae5732609f0c91e1488851280ee3deb4L3-R5) [[2]](diffhunk://#diff-5528ff946aa7212fedcb3a4bae8e67ebae5732609f0c91e1488851280ee3deb4L80-R87)
* [`frontend/src/stores/keyboardStore.ts`](diffhunk://#diff-ad2f197a47512152562c8adbbaff34b1d99496a1c4a6b3f858a8ad709c195b74R7): Updated keybindings to control terminal visibility. [[1]](diffhunk://#diff-ad2f197a47512152562c8adbbaff34b1d99496a1c4a6b3f858a8ad709c195b74R7) [[2]](diffhunk://#diff-ad2f197a47512152562c8adbbaff34b1d99496a1c4a6b3f858a8ad709c195b74L366-R369) [[3]](diffhunk://#diff-ad2f197a47512152562c8adbbaff34b1d99496a1c4a6b3f858a8ad709c195b74L376-R381)

### Store Updates:

* [`frontend/src/stores/terminalStore.ts`](diffhunk://#diff-89cc7d18715b0cc35d127109c6c6c7c57582dbef6c5f7dfe0be77ea502a55dd9R16-R18): Introduced a new `terminalVisibility` store to manage the visibility state of the terminal.