### PR TITLE
ci: fix windows build + cache

### DIFF
--- a/.github/actions/wails/action.yaml
+++ b/.github/actions/wails/action.yaml
@@ -158,7 +158,7 @@ runs:
     - name: Build Windows App
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}.exe -tags '${{inputs.build-tags}}'
       shell: bash
     - name: Build Windows App + Installer
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'true'

--- a/.github/workflows/editai-release.yaml
+++ b/.github/workflows/editai-release.yaml
@@ -27,6 +27,28 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      # Cache Go dependencies
+      - name: Set up Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Cache npm dependencies
+      - name: Set up npm cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - uses: ./.github/actions/wails
         with:
           build-name: editai
@@ -54,6 +76,28 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      # Cache Go dependencies
+      - name: Set up Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Cache npm dependencies
+      - name: Set up npm cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - uses: ./.github/actions/wails
         with:
           build-name: editai
@@ -85,6 +129,28 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      # Cache Go dependencies
+      - name: Set up Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Cache npm dependencies
+      - name: Set up npm cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend\node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - uses: ./.github/actions/wails
         with:
           build-name: editai


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to improve caching and modify the Windows build command. The most important changes include adding caching for Go and npm dependencies in the `editai-release.yaml` workflow and updating the build command for the Windows app in the `wails` action.

Caching improvements:

* [`.github/workflows/editai-release.yaml`](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR30-R51): Added caching for Go dependencies using `actions/cache@v3` with specific paths and keys for different operating systems. [[1]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR30-R51) [[2]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR79-R100) [[3]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR132-R153)
* [`.github/workflows/editai-release.yaml`](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR30-R51): Added caching for npm dependencies using `actions/cache@v3` with specific paths and keys for different operating systems. [[1]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR30-R51) [[2]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR79-R100) [[3]](diffhunk://#diff-f4083ebe6a83df1cb5e3c844b0d2d0ae46269a67b5b1c8083f7b43c85b8bdd1aR132-R153)

Build command modification:

* [`.github/actions/wails/action.yaml`](diffhunk://#diff-27891982add9cb4fb2aac9fee2fa412745978d97ae46cf3a9c249352914731ffL161-R161): Updated the build command for the Windows app to include the `.exe` extension in the output file name.