### PR TITLE
feat(makefile): now checks if wails is installed and supports newer linux versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build-mac:
 	$(GO_ENV) wails build -platform darwin/universal ${BUILD_OPTIONS}
 
 build-linux:
-	$(GO_ENV) wails build -platform linux/amd64 ${BUILD_OPTIONS} && \
+	$(GO_ENV) wails build ${WEBKIT_TAG} -platform linux/amd64 ${BUILD_OPTIONS} && \
 		cd build/debian && \
 		nfpm pkg --packager deb --target ../bin/ && \
 		nfpm pkg --packager rpm --target ../bin/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dev:
 	wails dev
 
 WEBKIT_TAG := $(shell \
-	if ! dpkg-query -W -f='${Status}' webkit2gtk-4.0 2>/dev/null | grep -q ""; then \
+	if ! pkg-config --exists webkit2gtk-4.0; then \
 		echo "-tags webkit2_41"; \
 	else \
 		echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ BUILD_OPTIONS := -clean -upx
 BUILD_TAGS := 
 GO_ENV := GOFLAGS="-buildvcs=false"
 
+WAILS_PATH := $(shell command -v wails 2>/dev/null)
+
+# If Wails is not installed, exit the make process
+ifeq ($(WAILS_PATH),)
+  $(error Wails is not installed. Please install Wails to proceed.)
+endif
+
 # Setup development environment
 configure:
 	docker compose up -d
@@ -13,9 +20,18 @@ configure:
 dev:
 	wails dev
 
+WEBKIT_TAG := $(shell \
+	if ! dpkg-query -W -f='${Status}' webkit2gtk-4.0 2>/dev/null | grep -q ""; then \
+		echo "-tags webkit2_41"; \
+	else \
+		echo ""; \
+	fi \
+)
+
 # Build development version
 build-dev:
-	$(GO_ENV) wails build
+	$(GO_ENV) wails build ${WEBKIT_TAG}
+
 
 # Build for different platforms
 build-windows:


### PR DESCRIPTION
- Simple validation that checks if wails (golang) is installed, if not return a appropriate message.

- Automatically adds the webkit tag to `build-dev` if trying to build in newer linux versions
> According to [wails docs](https://wails.io/docs/gettingstarted/installation) (Platform Specific Dependencies -> Linux) if `libwebkit2gtk-4.0-dev` is not found (or in the projects case, especifically webkit2gtk-4.0) you can use `libwebkit2gtk-4.1-dev`, but need to add `-tags webkit2_41` to tags.